### PR TITLE
Addressing some post-workshop items

### DIFF
--- a/docs/add-new-dataset.rst
+++ b/docs/add-new-dataset.rst
@@ -36,6 +36,7 @@ Next it is important to validate your newly created JSON file to ensure that the
 .. image:: _static/JSONFormatter.jpg
    :width: 400
    :class: align-left
+
 `JSON Formatter <https://jsonformatter.org/>`__  is one of the easiest, yet advanced, formatting and validating tools.  It can be used as a JSON validator, editor, and viewer.  While a login isn’t required to save your JSON data, data saved without a login becomes public.  To ensure that your data is private, create an account and login first.  
 
 

--- a/docs/dataarc-tool-help.rst
+++ b/docs/dataarc-tool-help.rst
@@ -35,9 +35,10 @@
 What is the dataARC search tool?
 =================================
 
-This dataARC search tool is designed to help students and researchers discover and explore diverse interconnected data sources relevant for interdisciplinary studies of long-term human ecodynamics in the North Atlantic. Search results produced through this tool will include data provided by specialists in different domains, information about the connections between these datasets, and background information about the data sources and how they are typically used. The aim of the tool is to encourage users to assess the potential relevance to their research of datasets from outside their own area of expertise. It’s important to understand how datasets are interconnected in the tool to apply filters effectively and interpret your search results correctly. 
+This dataARC search tool is designed to help students and researchers discover and explore diverse interconnected data sources relevant for interdisciplinary studies of long-term human ecodynamics in the North Atlantic. Search results produced through this tool will include data provided by specialists in different domains, information about the connections between these datasets, and background information about the data sources and how they are typically used. The aim of the tool is to encourage users to assess the potential relevance to their research of datasets from outside their own area of expertise. It’s important to understand how datasets are interconnected in the tool to apply filters effectively and interpret your search results correctly.
 
 .. image:: _static/dataarc.jpg
+
 
 What kind of data is available through the search tool?
 ----------------------------------------------------------
@@ -85,7 +86,7 @@ Create a Temporal Filter for a predefined time period.
 
 Archaeologists, geologists, climatologists, and literary historians all think about time differently. Predefined time periods are focused on discrete events (e.g. the Indonesian volcano eruption in 1257), rapid events (e.g. the Black Death in Norway from 1347-1350), or larger periods of time (e.g. the Early Medieval Period from 1050-1250) that are commonly referenced in the different disciplines represented in dataARC.  
 
-1.  To see a list of the available predefined time periods,  select the dropdown list under *Time Period*.
+1.  To see a list of the available predefined time periods, select the drop down list under *Time Period*.
 
 2.  Choose a predefined time period. 
 
@@ -95,7 +96,7 @@ Archaeologists, geologists, climatologists, and literary historians all think ab
 
 
 Quick Results Evaluation (optional)
---------------------------------
+-----------------------------------
 .. image:: _static/filter_box.jpg
    :width: 400
    :class: align-left
@@ -122,7 +123,7 @@ Assess data availability for an area/country of interest and create a spatial fi
 
 
 Quick Results Evaluation (optional)
---------------------------------
+-----------------------------------
 1.  Once the filter has been applied, the gray Filter and Results dialogue box on the right of the screen will update to show the new filter and results subsets.
 
 2.  Click on the Matched, Related, or Contextual texts to go to the appropriate result section at the bottom of the screen (and go to `Interpreting Results <#interpreting-results-why-do-i-have-three-sets-of-results>`__) or continue on to another section to add another filter.
@@ -156,7 +157,7 @@ Explore the concept map, observe concepts and their connections.  Create a conce
 
 
 Quick Results Evaluation (optional)
---------------------------------
+------------------------------------
 1.  Once the filter has been applied, the gray *Filters and Results* dialogue box on the right of the screen will update to show the new filter and results subsets.
 
 2.  Click on the Matched, Related, or Contextual links to go to the appropriate result section at the bottom of the screen (and go to `Interpreting Results <#interpreting-results-why-do-i-have-three-sets-of-results>`__) or continue on to another section to add another filter.
@@ -203,7 +204,7 @@ Now that you are successfully logged in, you are ready to download your data.  G
 
 .. image:: _static/SaveSearch.jpg
 
-The newly saved dataset can now be accessed in your dataARC profile.  Select Manage - Profile (replaced Login text) located at the top right of the menu.  Your new dataset will be listed under Saved Searches.   Select Request Download to download the data in jSON format.  If you are interested in previewing what datasets are in your search result, go to the :ref:`Results Preview<Results - Preview the data>` section.  To better understand the three types of results (matched, related, and contextual), refer to the :ref:`Interpreting Results<Interpreting Results: Why do I have three sets of results?>` section below.  To better understand **why** you recieved the results that you did, visit the :ref:`Why?<Why? An interactive visualization tool for understanding your results>` Section.
+The newly saved dataset can now be accessed in your dataARC profile.  Select Manage - Profile (replaced Login text) located at the top right of the menu.  Your new dataset will be listed under Saved Searches.   Select Request Download to download the data in jSON format.  If you are interested in previewing what datasets are in your search result, go to the :ref:`Results Preview<Results - Preview the data>` section.  To better understand the three types of results (matched, related, and contextual), refer to the :ref:`Interpreting Results<Interpreting Results: Why do I have three sets of results?>` section below.  To better understand **why** you received the results that you did, visit the :ref:`Why?<Why? An interactive visualization tool for understanding your results>` Section.
 
 Interpreting Results: Why do I have three sets of results?   
 ===============================================================
@@ -267,7 +268,7 @@ In the dataARC search tool, the most directly connected concepts and their mappe
 Why not just group all the direct, related and contextual results together?
 ---------------------------------------------------------------------------
 
-The dataARC search tool could, of course, group together all the results, rather than splitting them out based on how closely, conceptually speaking, they are related to the original search term. We’ve chosen to structure the results by how closely they are connected to the original search term, and to expose the explanations of these connections to help users to understand how experts from diverse domains have assessed the relevance of their data to shared different concepts. 
+The dataARC search tool could, of course, group together all the results, rather than splitting them out based on how closely, conceptually speaking, they are related to the original search term. We've chosen to structure the results by how closely they are connected to the original search term, and to expose the explanations of these connections to help users to understand how experts from diverse domains have assessed the relevance of their data to shared different concepts. 
 
 Because the data and disciplines collected together through the dataARC search tool are so diverse, it’s likely that as a user you will encounter data with which you’re really quite unfamiliar and find yourself uncertain about how relevant it is to your original search terms and what that relevance might be. The *direct*, *related* and *contextual* tiers of search results indicate the degree of relevance. 
  
@@ -278,12 +279,14 @@ Before you download your data, you can preview the different datasets returned f
 
 .. image:: _static/results.jpg
 
-Why? An interactive visualization tool for understanding your results
-=====================================================================
+.. _why-a-powerful-visualization-tool-for-understanding-your-results:
 
-.. image:: _static/LinkedViewHuman.png
+Why? An interactive visualization tool for understanding your results
+======================================================================
 
 The *Why* section is broken into 6 linked-view panels to help you to understand *why* the tool has returned your filtered search results. This section of the tool exposes relationships that not only exist between the different concepts used in your search, but also between concepts and related data (combinators). The combinators have been handcrafted by dataset creators and domain experts and are intended to enable users from other disciplines to discover the conceptual links which are implicit in domain-specific knowledge, which wouldn't be obvious outside the specialist research community. These connections are described with reference to key literature in each domain. These descriptions and citations can be accessed in the "Combinator details" panel.
+
+.. image:: _static/LinkedViewHuman.png
 
 The 3 panels along the top portion of this section display the concepts, combinators, and datasets (from left to right) returned by your query (in the sample shown above, only the concept "human" was queried), while the panels in the lower portion update to show the details for concepts, combinators, and datasets selected elsewhere in the *Why* section. In any of the 6 linked views, clicking on concepts or combinator items allows you to see additional details. Hovering over concepts or combinators will highlight them in any box where they are displayed (the example above shows the result of hovering over the "humans" concept), enabling you to see connections, and whether they were included in your query.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,18 +31,54 @@
 .. image:: _static/dataarc_logo_final_sml.png
    :class: align-center
   
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   index
+   dataarc-tool-help
+   dataarc-api
+   ecosystem_explorer
+   add-new-dataset
   
 Accompanying the |DPW| and the |DST|, this guide provides "how-to" information on all things dataARC.  The result of two successful NSF awards (cyberNABO 1.0 and 2.0 - SMA 1439389 and1637076) and a strong international research collaboration, dataARC bridges data from the humanities to the environmental sciences to support the interdisciplinary study of human ecodynamics in the North Atlantic.  Read more about the project background, the research team, and the wide array of datasets available in dataARC on the |DPW| and learn how to use the |DST| in your research. You may also find the dataARC API useful in your project. Learn more about it by visiting the `API Documentation page <dataarc-api.html>`__.
 
 Reference the `dataARC Search Tool Help <dataarc-tool-help.html>`__ to learn how to use the temporal, spatial, and conceptual visualization graphs, how to create and combine filters, and how to download and interpret your results.  Finally, interested in adding your data to dataARC?  DataARC is built to encourage and support open data and collaboration. :ref:`Interested in Adding your data?  Learn how...`.
 
+Getting Started
+================
 
-`DataARC Search Tool Help <dataarc-tool-help.html>`__
-========================
+Scientists and researchers who are interested in exploring concepts and datasets related to the changing landscape in the North Atlantic, consider starting with the :ref:`DataARC Search Tool` section.
+
+For those interested in data analytics and automated data retrieval, you might be interested in the :ref:`DataARC API` and the :ref:`DataARC Ecosystem Explorer` tool boxes.
+
+Maybe you have decided dataARC would be a great fit for your data, or you would like to map data to concepts. Navigate to the :ref:`Interested in Adding your data? Learn how...` section.
+
+DataARC Search Tool
+====================
+
 .. image:: _static/dataarc.jpg
    :width: 400
    :class: align-left
-The |dst| is the online interface that allows users to query the archaeological, textual, and environmental data in dataARC.  Learn how to filter data temporally, spatially, conceptually, and by keyword search.  Use `this guide <dataarc-tool-help.html>`__ to better understand how the dynamic data visualization graphs work, how to filter and optimize your results, and also how to download your data.  
+
+The |dst| is the online interface that allows users to query the archaeological, textual, and environmental data in dataARC. Learn how to filter data temporally, spatially, conceptually, and by keyword search.  Use `this guide <dataarc-tool-help.html>`__ to better understand how the dynamic data visualization graphs work, how to filter and optimize your results, and also how to download your data.
+
+DataARC API
+===========
+
+Find more information about using the dataARC API by visiting the `API Documentation page <dataarc-api.html>`__.
+
+Use cases are demonstrated in Python with `this Jupyter Notebook <https://github.com/ropitz/dataarc-notebook/blob/main/use_cases_examples.ipynb>`
+
+
+DataARC Ecosystem Explorer
+==========================
+
+The |dee| is a virtual sandbox designed to help dataset contributors think through mapping their data to the dataARC community's knowledge map of the concept of "changing landscapes." It is also designed to help advanced users better understand how data and concepts are connected in the dataARC Ecosystem. Use `this guide <ecosystem_explorer.html>`__ to walk you through learning the Ecosystem Explorer tool set that is provided as a Jupyter Notebook.
+
+|DNOA2| allows you to calculate graph metrics like betweenness centrality on the dataARC concept map.  It is a useful tool for beginning high-level exploration of how different concepts are connected and currently runs off of the dataARC API (check out the `dataARC API documentation <dataarc-api.html>`__).
+
 
 
 Interested in Adding your data?  Learn how...
@@ -50,36 +86,30 @@ Interested in Adding your data?  Learn how...
 
 Preparing your data for ingest into dataARC will be a multi-step process.  If you haven't already, familiarize yourself with the |DST| and take a thorough glance of the contents of the |DPW| to better understand the project context and how the data are structured.  Next, you will want to step through each of the sections below.
   
-   
+
 1. A |WS2| to Developing Good Mappings for your Data
 ----------------------------------------------------------------
 .. image:: _static/dataARC_chart3.jpg
    :width: 400
    :class: align-left
-Thinking about how to map your data to the dataARC community's shared concept map can be challenging. Graduate students working with the project team have developed materials to guide PhD students considering contributing their data. |ws| designed to be used in a workshop, are relevant to anyone considering contributing project data to the dataARC Ecosystem and should be reviewed before creating combinators for your dataset. 
 
+Thinking about how to map your data to the dataARC community's shared concept map can be challenging. Graduate students working with the project team have developed materials to guide PhD students considering contributing their data. |ws| designed to be used in a workshop, are relevant to anyone considering contributing project data to the dataARC Ecosystem and should be reviewed before creating combinators for your dataset.
 |
 |
 
-2. `Learn how <ecosystem_explorer.html>`__ to use the dataARC Ecosystem Explorer! 
-----------------------------------------------------------------------------------
-The |dee| is a virtual sandbox designed to help dataset contributors think through mapping their data to the dataARC community's knowledge map of the
-concept of "changing landscapes." It is also designed to help advanced users better understand how data and concepts are connected in the
-dataARC Ecosystem. Use `this guide <ecosystem_explorer.html>`__ to walk you through learning the Ecosystem Explorer tool set that is provided as a Jupyter Notebook.  
-
-|DNOA2| allows you to calculate graph metrics like betweenness centrality on the dataARC concept map.  It is a useful tool for beginning high-level exploration of how different concepts are connected and currently runs off of the dataARC API (check out the `dataARC API documentation <dataarc-api.html>`).
-
-
-3. Add your dataset using Github
+2. Add your dataset using Github
 ----------------------------------
 .. image:: _static/GitHub.png
    :width: 150
    :class: align-left
-Now that you have a better understanding of how to map your data to the dataARC concept map and you've experimented with creating combinators using the dataARC Ecosystem Explorer, you are ready to begin uploading your data into dataARC.  `Click here <add-new-dataset.html>`__ for step-by-step guidance for creating your dataset, uploading it to GitHub, and creating combinators in dataARC.  
+
+Now that you have a better understanding of how to map your data to the dataARC concept map and you've experimented with creating combinators using the dataARC Ecosystem Explorer, you are ready to begin uploading your data into dataARC.  `Click here <add-new-dataset.html>`__ for step-by-step guidance for creating your dataset, uploading it to GitHub, and creating combinators in dataARC.
 
 
 
-4. Register as a contributor
+3. Register as a contributor
 ----------------------------
 
 Fill out the `dataARC contributor form <https://www.data-arc.org/request-to-be-a-data-contributor/>`__ to register as a member of the dataARC contributors team.
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,7 +69,7 @@ DataARC API
 
 Find more information about using the dataARC API by visiting the `API Documentation page <dataarc-api.html>`__.
 
-Use cases are demonstrated in Python with `this Jupyter Notebook <https://github.com/ropitz/dataarc-notebook/blob/main/use_cases_examples.ipynb>`
+Use cases are demonstrated in Python with `this Jupyter Notebook <https://github.com/ropitz/dataarc-notebook/blob/main/use_cases_examples.ipynb/>`__
 
 
 DataARC Ecosystem Explorer

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,10 +67,9 @@ The |dst| is the online interface that allows users to query the archaeological,
 DataARC API
 ===========
 
-Find more information about using the dataARC API by visiting the `API Documentation page <dataarc-api.html>`__.
+The dataARC REST API is a useful tool for gathering, exploring, and modifying dataARC information to help researchers interested in automation and deeper data analytics. Find more information about using the dataARC API by visiting the `API Documentation page <dataarc-api.html>`__.
 
 Use cases are demonstrated in Python with `this Jupyter Notebook <https://github.com/ropitz/dataarc-notebook/blob/main/use_cases_examples.ipynb/>`__
-
 
 DataARC Ecosystem Explorer
 ==========================


### PR DESCRIPTION
- Reorg home page so that Table of Contents emphasizes the main dataARC tools (Search Tool, API, and EcoSystem Explorer)
- Add a "Getting Started" section for different types of users.
- Add link to Rachel's fork for API Examples notebook
- Attempted to fix the anchor for Why section documentation referenced from Search Tool Why
- Added hidden table of contents to enable "Next" and "Previous" sections in navigation panel.